### PR TITLE
Update LicenseCheckExtension.kt

### DIFF
--- a/src/main/kotlin/io/github/woolph/gradle/licensecheck/LicenseCheckExtension.kt
+++ b/src/main/kotlin/io/github/woolph/gradle/licensecheck/LicenseCheckExtension.kt
@@ -69,8 +69,10 @@ abstract class LicenseCheckExtension @Inject constructor(project: Project) : Ski
             "The 2-Clause BSD License",
             "The 3-Clause BSD License",
             "GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception",
+            "GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1"
             "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0",
             "Eclipse Public License - v 1.0",
+            "Eclipse Public License - v 2.0",
             "PUBLIC DOMAIN",
             "Bouncy Castle Licence", // is essentially the "MIT License"
         ),


### PR DESCRIPTION
Allow "Eclipse Public License - v 2.0" and "GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1"