### PR TITLE
mandatory Upgrade owasp dependency-check

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 jvmTarget = "11"
 
 [libraries]
-dependencyCheck = "org.owasp:dependency-check-gradle:9.1.0"
+dependencyCheck = "org.owasp:dependency-check-gradle:10.0.4"
 licenseReport = "com.github.jk1:gradle-license-report:2.7"
 kotlinxDatetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.5.0"
 kotlinxSerialization-core = "org.jetbrains.kotlinx:kotlinx-serialization-core:1.6.3"


### PR DESCRIPTION
The Version that is  imported  from qualityCheckPlugin -> 9.1.0  and from an Issue is  recommended that we should mandatory upgrade to Version >= 10.0.2.

With the old Version of owasp dependency check plugin 9.1.0  CVE-2015-0244 is wrongly  flagged for some Libraries.
https://github.com/jeremylong/DependencyCheck/issues/6879#issuecomment-2273395803 
https://github.com/jeremylong/DependencyCheck/issues/6817 